### PR TITLE
Update Dungeons.cs

### DIFF
--- a/~DungeonReset/Scripts/Dungeons.cs
+++ b/~DungeonReset/Scripts/Dungeons.cs
@@ -121,7 +121,8 @@ namespace DungeonReset
                 if (bounds.Contains(player.transform.position))
                 {
                     Main.Log.LogWarning($"Dungeon '{timer.dungeon.GetCleanName()}' couldn't regenerate because a player was found inside!\n");
-                    Schedule(timer.dungeon, playerProtectionInterval);
+                    //Schedule(timer.dungeon, playerProtectionInterval);
+                    timer.dungeon.SetLastReset(DateTimeOffset.Now.AddSeconds(playerProtectionInterval));
                     return false;
                 }
 


### PR DESCRIPTION
PlayerProtection dates the last reset to a future point in time. Now the reset interval can be set to a small value, e.g. a few seconds, and the PlayerProtectionInterval to the desired reset time. Prevents occasional stacking of items and enemies due to loading errors.